### PR TITLE
#10 Add explicit route for 3.2 compatibility

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,0 +1,7 @@
+---
+Name: messagequeueroutes
+After: '#rootroutes'
+---
+Director:
+  rules:
+    'MessageQueue_Process': 'MessageQueue_Process'


### PR DESCRIPTION
MessageQueue::consume_on_shutdown calls sake with the route MessageQueue_Process.

SS3.1 provided automatic routing by controller name, which let this work; this was removed in SS3.2.

I have added an explicit route.